### PR TITLE
Add dot to iskeyword

### DIFF
--- a/ftplugin/ansible.lua
+++ b/ftplugin/ansible.lua
@@ -11,3 +11,5 @@ if fname:find('tasks/') then
   }
   vim.bo.path = table.concat(paths, ",")
 end
+
+vim.bo.iskeyword = "@,48-57,_,192-255,."


### PR DESCRIPTION
The ansible-language-server returns completion candidates like
`ansible.builtin.file`, typing a `.` should not end completion.
