### PR TITLE
feat(ansible.lua): add ft support for molecule Ansible's test suite

### DIFF
--- a/ftdetect/ansible.lua
+++ b/ftdetect/ansible.lua
@@ -9,6 +9,7 @@ if vim.filetype then
       [".*/roles/.*/tasks/.*%.ya?ml"] = "yaml.ansible",
       [".*/roles/.*/handlers/.*%.ya?ml"] = "yaml.ansible",
       [".*/tasks/.*%.ya?ml"] = "yaml.ansible",
+      [".*/molecule/.*%.ya?ml"] = "yaml.ansible",
     },
   })
 else
@@ -30,6 +31,8 @@ else
       "*/roles/*/handlers/*.yaml",
       "*/tasks/*.yml",
       "*/tasks/*.yaml",
+      "*/molecule/*.yml",
+      "*/molecule/*.yaml",
     },
     callback = function()
       vim.bo.filetype = "yaml.ansible"


### PR DESCRIPTION
Molecule also uses Ansible's playbooks to tests roles/playbooks/tasks, so is worth to add support for those playbooks