### PR TITLE
Stop overriding `iskeyword`

### DIFF
--- a/ftplugin/ansible.lua
+++ b/ftplugin/ansible.lua
@@ -12,5 +12,3 @@ if fname:find('tasks/') then
   }
   vim.bo.path = table.concat(paths, ",")
 end
-
-vim.bo.iskeyword = "@,48-57,_,192-255,."


### PR DESCRIPTION
The idea behind including `.` in `iskeyword` was to enable completion
for the modules (e.g. `ansible.builtin.copy`) but not having other
operations - like `cw` - work as usual is confusing.

With completion solutions like `vim.lsp.completion` the `iskeyword`
addition is also no longer as important, because it prioritizes the word
boundary reported by the language server.
